### PR TITLE
Fix a bug where PlayClient don't respect the input address of WlanProxy

### DIFF
--- a/src/pspnetparty/client/swt/ConnectAddressDialog.java
+++ b/src/pspnetparty/client/swt/ConnectAddressDialog.java
@@ -97,6 +97,13 @@ public class ConnectAddressDialog extends Dialog {
 			hostnameText.setLayoutData(gridData);
 
 			hostnameText.setFocus();
+			hostnameText.addModifyListener(new ModifyListener() {
+				@Override
+				public void modifyText(ModifyEvent e) {
+					Text hostnameText = (Text) e.widget;
+					hostname = hostnameText.getText();
+				}
+			});
 		}
 		{
 			Label label = new Label(composite, SWT.NONE);


### PR DESCRIPTION
PlayClient don't read the address textbox when connecting to WlanProxy, and always connect to localhost

please check the patch
